### PR TITLE
Set Numeric locale to `en_US.utf8` avoid Float conversion issues

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -1,5 +1,5 @@
 name: glustercli
-version: 0.1.3
+version: 0.1.4
 
 authors:
   - Aravinda Vishwanathapura <mail@aravindavk.in>

--- a/src/helpers.cr
+++ b/src/helpers.cr
@@ -3,7 +3,10 @@ module GlusterCLI
   def self.execute_cmd(cmd, args)
     stdout = IO::Memory.new
     stderr = IO::Memory.new
-    status = Process.run(cmd, args: args, output: stdout, error: stderr)
+    # Set numeric locale to en_US.utf8 to avoid all
+    # float conversion issues
+    status = Process.run(cmd, args: args, output: stdout, error: stderr,
+      env: {"LC_NUMERIC" => "en_US.utf8"})
     {status.exit_code, stdout.to_s, stderr.to_s}
   end
 

--- a/src/process_metrics.cr
+++ b/src/process_metrics.cr
@@ -83,8 +83,8 @@ module GlusterCLI
         parts = line.split
 
         proc = pids_index[parts[0].strip.to_i]
-        proc.pcpu = parts[8].strip.to_f
-        proc.pmem = parts[9].strip.to_f
+        proc.pcpu = parts[8].strip.gsub(",", "").to_f
+        proc.pmem = parts[9].strip.gsub(",", "").to_f
       end
     end
   end


### PR DESCRIPTION
External commands like `top` uses the system locale to print the numerics.

Example:

```console
$ LC_NUMERIC=it_IT.utf8 printf "%'6.2f\n" 123456789
123.456.789,00
LC_NUMERIC=en_US.utf8 printf "%'6.2f\n" 123456789
123,456,789.00
```

Signed-off-by: Aravinda Vishwanathapura <mail@aravindavk.in>