### PR TITLE
Fixed distCount issue

### DIFF
--- a/lint/shard.lock
+++ b/lint/shard.lock
@@ -2,5 +2,5 @@ version: 2.0
 shards:
   ameba:
     git: https://github.com/crystal-ameba/ameba.git
-    version: 0.14.3
+    version: 1.0.0
 

--- a/lint/shard.yml
+++ b/lint/shard.yml
@@ -1,8 +1,8 @@
 name: lint
-version: 0.1.0
+version: 0.2.0
 
 authors:
-  - Kadalu.io <engineering@kadalu.io>
+  - Aravinda Vishwanathapura <mail@aravindavk.in>
 
 description: |
   To install Lint tool Ameba
@@ -12,3 +12,4 @@ license: GPLv3
 development_dependencies:
   ameba:
     github: crystal-ameba/ameba
+    version: ~> 1.0.0

--- a/shard.yml
+++ b/shard.yml
@@ -1,5 +1,5 @@
 name: glustercli
-version: 0.1.4
+version: 0.2.0
 
 authors:
   - Aravinda Vishwanathapura <mail@aravindavk.in>

--- a/src/types.cr
+++ b/src/types.cr
@@ -121,7 +121,13 @@ module GlusterCLI
     end
 
     def subvol_size
-      @bricks.size / @distribute_count
+      if @replica_count > 1
+        @replica_count
+      elsif @disperse_count > 0
+        @disperse_count
+      else
+        1
+      end
     end
   end
 end

--- a/src/volume.cr
+++ b/src/volume.cr
@@ -59,8 +59,6 @@ module GlusterCLI
             volume.snapshot_count = ele.content.strip.to_i
           when "brickCount"
             volume.brick_count = ele.content.strip.to_i
-          when "distCount"
-            volume.distribute_count = ele.content.strip.to_i
           when "replicaCount"
             volume.replica_count = ele.content.strip.to_i
           when "arbiterCount"
@@ -73,6 +71,7 @@ module GlusterCLI
             nil
           end
         end
+        volume.distribute_count = (volume.brick_count / volume.subvol_size).to_i
 
         brks = vol.xpath_nodes(".//brick")
         brks.each do |brk|


### PR DESCRIPTION
Sometimes Gluster XML returns wrong distCount. Use different logic
to get distribute count instead of depending on `distCount` field.

Updates: https://github.com/kadalu/gluster-metrics-exporter/issues/29
Signed-off-by: Aravinda Vishwanathapura <mail@aravindavk.in>